### PR TITLE
WIP: Update for syntax from the distro 3.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.10]
+
+* updated for syntax from the distro 3.19.0
+
 ## [0.3.8]
 
 * fixed snippets for the date snippet variables introduced in VSC 1.20.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsc-logtalk",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vsc-logtalk",
     "displayName": "VSC-Logtalk",
     "description": "Support for Logtalk language",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "publisher": "arthurwang",
     "icon": "images/logtalk.png",
     "license": "MIT",

--- a/syntaxes/Logtalk.tmLanguage
+++ b/syntaxes/Logtalk.tmLanguage
@@ -189,7 +189,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(true|fa(il|lse)|repeat|instantiation_error)\b(?![-!(^~])</string>
+			<string>\b(true|fa(il|lse)|repeat|(instantiation|system)_error)\b(?![-!(^~])</string>
 			<key>name</key>
 			<string>support.function.control.logtalk</string>
 		</dict>
@@ -201,7 +201,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((type|domain|existence|permission|representation|evaluation|resource)_error)(?=[(])</string>
+			<string>\b((type|domain|existence|permission|representation|evaluation|resource|syntax)_error)(?=[(])</string>
 			<key>name</key>
 			<string>support.function.control.logtalk</string>
 		</dict>
@@ -273,7 +273,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(logtalk_(compile|l(ibrary_path|oad|oad_context)|make))(?=[(])</string>
+			<string>\b(logtalk_(compile|l(ibrary_path|oad|oad_context)|make(_target_action)?))(?=[(])</string>
 			<key>name</key>
 			<string>support.function.compiling-and-loading.logtalk</string>
 		</dict>


### PR DESCRIPTION
Created as WIP as the `CHANGELOG.md` file is missing the description of changes in the current version, 0.3.9. Can you fill the missing information?

A second question: is the contents of the `snippets/logtalk.json` file generated manually or automatically? In this pull request, is currently missing the description of the new built-in predicates.